### PR TITLE
Add dynamic meal plan module

### DIFF
--- a/MMM-Sundpaabudget/MMM-Sundpaabudget.js
+++ b/MMM-Sundpaabudget/MMM-Sundpaabudget.js
@@ -1,0 +1,35 @@
+Module.register("MMM-Sundpaabudget", {
+  defaults: {
+    updateInterval: 12 * 60 * 60 * 1000 // 12 hours
+  },
+
+  start: function() {
+    this.mealPlan = null;
+    this.loadData();
+    var self = this;
+    setInterval(function() {
+      self.loadData();
+    }, this.config.updateInterval);
+  },
+
+  loadData: function() {
+    this.sendSocketNotification("GET_MEAL_PLAN");
+  },
+
+  socketNotificationReceived: function(notification, payload) {
+    if (notification === "MEAL_PLAN") {
+      this.mealPlan = payload;
+      this.updateDom();
+    }
+  },
+
+  getDom: function() {
+    var wrapper = document.createElement("div");
+    if (!this.mealPlan) {
+      wrapper.innerHTML = "Loading meal plan...";
+    } else {
+      wrapper.innerHTML = this.mealPlan;
+    }
+    return wrapper;
+  }
+});

--- a/MMM-Sundpaabudget/README.md
+++ b/MMM-Sundpaabudget/README.md
@@ -1,0 +1,27 @@
+# MMM-Sundpaabudget
+
+This MagicMirror² module displays the weekly meal plan from **Sund på Budget**.
+The module automatically updates the URL based on the current ISO week number
+and year.
+
+## Installation
+
+1. Clone this repository into your `modules` folder of MagicMirror²:
+   ```bash
+   git clone <repo-url> MMM-Sundpaabudget
+   ```
+2. Install dependencies:
+   ```bash
+   cd MMM-Sundpaabudget
+   npm install
+   ```
+3. Add the module to the `config.js` of your MagicMirror setup:
+   ```javascript
+   {
+     module: "MMM-Sundpaabudget",
+     position: "top_left",
+   }
+   ```
+
+The module fetches the meal plan once every twelve hours and displays the
+content from `https://sundpaabudget.dk`.

--- a/MMM-Sundpaabudget/node_helper.js
+++ b/MMM-Sundpaabudget/node_helper.js
@@ -1,0 +1,41 @@
+const NodeHelper = require("node_helper");
+const fetch = require("node-fetch");
+const cheerio = require("cheerio");
+
+module.exports = NodeHelper.create({
+  start: function() {
+    console.log("MMM-Sundpaabudget helper started");
+  },
+
+  socketNotificationReceived: function(notification, payload) {
+    if (notification === "GET_MEAL_PLAN") {
+      this.getMealPlan();
+    }
+  },
+
+  getMealPlan: async function() {
+    const { week, year } = getISOWeekYear(new Date());
+    const url = `https://sundpaabudget.dk/sund-madplan-uge-${week}-${year}/`;
+    try {
+      const response = await fetch(url);
+      const body = await response.text();
+      const $ = cheerio.load(body);
+      const content = $(".entry-content").html() || "Kunne ikke hente madplan.";
+      this.sendSocketNotification("MEAL_PLAN", content);
+    } catch (error) {
+      console.error("MMM-Sundpaabudget: Failed to fetch", error);
+      this.sendSocketNotification(
+        "MEAL_PLAN",
+        "Error fetching meal plan."
+      );
+    }
+  }
+});
+
+function getISOWeekYear(date) {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+  return { week: week, year: d.getUTCFullYear() };
+}

--- a/MMM-Sundpaabudget/package.json
+++ b/MMM-Sundpaabudget/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "MMM-Sundpaabudget",
+  "version": "1.0.0",
+  "description": "MagicMirror module that shows weekly meal plan from sundpaabudget.dk",
+  "main": "MMM-Sundpaabudget.js",
+  "dependencies": {
+    "node-fetch": "^2.6.7",
+    "cheerio": "^1.0.0-rc.12"
+  }
+}


### PR DESCRIPTION
## Summary
- create MMM-Sundpaabudget module that fetches the weekly meal plan
- add `node_helper.js` to compute week/year, build URL and fetch the content
- include README and package.json for installation instructions

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6850192fe91c8332b22ef1e1e1ecad0d